### PR TITLE
Add ability to ignore prefixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,28 +5,24 @@ var isVendorPrefixed = require('is-vendor-prefixed')
 
 module.exports = postcss.plugin('postcss-remove-prefixes', function (options) {
   if (!options) {
-    options = {};
+    options = {
+      ignore: []
+    }
   }
 
-  var ignore = options.ignore ? Array.isArray(options.ignore) ? options.ignore : false : [];
-
-  if (ignore === false) {
+  if (!Array.isArray(options.ignore)) {
     throw TypeError("options.ignore must be an array")
   }
 
-  for (var i = 0; i < ignore.length; ++i) {
-    var value = ignore[i];
-
-    if (typeof value === "string") {
-      value = new RegExp(value + "$", "i")
+  var ignore = options.ignore.map(function (value) {
+    if (typeof value === 'string') {
+      return new RegExp(value + '$', 'i')
     } else if (value instanceof RegExp) {
-
+      return value
     } else {
-      throw TypeError("options.ignore values can either be a string or a regular expression")
+      throw TypeError('options.ignore values can either be a string or a regular expression')
     }
-
-    ignore[i] = value;
-  }
+  })
 
   return function removePrefixes(root, result) {
     root.walkDecls(function (declaration) {

--- a/index.js
+++ b/index.js
@@ -3,11 +3,44 @@
 var postcss = require('postcss')
 var isVendorPrefixed = require('is-vendor-prefixed')
 
-module.exports = postcss.plugin('postcss-remove-prefixes', function () {
-  return function removePrefixes (root, result) {
+module.exports = postcss.plugin('postcss-remove-prefixes', function (options = {}) {
+  let ignore = options.ignore ? Array.isArray(options.ignore) ? options.ignore : false : [];
+
+  if (ignore === false) {
+    throw TypeError("options.ignore must be an array")
+  }
+
+  for (let i = 0; i < ignore.length; ++i) {
+    let value = ignore[i];
+
+    if (typeof value === "string") {
+      value = new RegExp(value + "$", "i")
+    } else if (value instanceof RegExp) {
+
+    } else {
+      throw TypeError("options.ignore values can either be a string or a regular expression")
+    }
+
+    ignore[i] = value;
+  }
+
+  return function removePrefixes(root, result) {
     root.walkDecls(function (declaration) {
       if (isVendorPrefixed(declaration.prop) || isVendorPrefixed(declaration.value)) {
-        declaration.remove()
+        let isIgnored = false;
+
+        for (let i = 0; i < ignore.length; ++i) {
+          let value = ignore[i];
+
+          if (value.test(declaration.prop)) {
+            isIgnored = true;
+            break;
+          }
+        }
+
+        if (!isIgnored) {
+          declaration.remove()
+        }
       }
     })
   }

--- a/index.js
+++ b/index.js
@@ -7,15 +7,15 @@ module.exports = postcss.plugin('postcss-remove-prefixes', function (options) {
   if (!options) {
     options = {};
   }
-  
-  let ignore = options.ignore ? Array.isArray(options.ignore) ? options.ignore : false : [];
+
+  var ignore = options.ignore ? Array.isArray(options.ignore) ? options.ignore : false : [];
 
   if (ignore === false) {
     throw TypeError("options.ignore must be an array")
   }
 
-  for (let i = 0; i < ignore.length; ++i) {
-    let value = ignore[i];
+  for (var i = 0; i < ignore.length; ++i) {
+    var value = ignore[i];
 
     if (typeof value === "string") {
       value = new RegExp(value + "$", "i")
@@ -31,10 +31,10 @@ module.exports = postcss.plugin('postcss-remove-prefixes', function (options) {
   return function removePrefixes(root, result) {
     root.walkDecls(function (declaration) {
       if (isVendorPrefixed(declaration.prop) || isVendorPrefixed(declaration.value)) {
-        let isIgnored = false;
+        var isIgnored = false;
 
-        for (let i = 0; i < ignore.length; ++i) {
-          let value = ignore[i];
+        for (var i = 0; i < ignore.length; ++i) {
+          var value = ignore[i];
 
           if (value.test(declaration.prop)) {
             isIgnored = true;

--- a/index.js
+++ b/index.js
@@ -3,7 +3,11 @@
 var postcss = require('postcss')
 var isVendorPrefixed = require('is-vendor-prefixed')
 
-module.exports = postcss.plugin('postcss-remove-prefixes', function (options = {}) {
+module.exports = postcss.plugin('postcss-remove-prefixes', function (options) {
+  if (!options) {
+    options = {};
+  }
+  
   let ignore = options.ignore ? Array.isArray(options.ignore) ? options.ignore : false : [];
 
   if (ignore === false) {

--- a/test/fixtures/input.css
+++ b/test/fixtures/input.css
@@ -6,5 +6,9 @@
   display: -moz-flex;
   display: flex;
   -webkit-flex: 1;
+  -webkit-font-smoothing: antialiased;
+  -webkit-transform: none;
+  -moz-transform: none;
   flex: 1;
 }
+

--- a/test/fixtures/output.css
+++ b/test/fixtures/output.css
@@ -3,5 +3,8 @@
  */
 .flex {
   display: flex;
+  -webkit-font-smoothing: antialiased;
+  -moz-transform: none;
   flex: 1;
 }
+

--- a/test/test.js
+++ b/test/test.js
@@ -18,7 +18,7 @@ function fixture (name) {
 
 function test (input, output) {
   assert.deepEqual(
-    postcss([ postcssRemovePrefixes() ])
+    postcss([ postcssRemovePrefixes({ ignore: [ "font-smoothing", /^-moz-transform$/i ] }) ])
       .process(fixture(input)).css,
     fixture(output)
   )


### PR DESCRIPTION
For #3  

Options

ignore: Must be an array or Strings, or regular expression.

```js

{
    ignore: [
        // Do not remove prefixes, that end with a given string
        // Will ignore -webkit-font-smoothing, -moz-font-smoothing, etc.
        "font-smoothing", 
        // Do not ignore prefixes, that match the given regular expression
        // Will only ignore -moz-transform.
        /^-moz-transform$/i 
    ]
}
```
